### PR TITLE
Generics support for derive, specify accounting rules.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "get-size"
 description = "Determine the size in bytes an object occupies inside RAM."
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Denis Kerp"]
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["size", "heap", "ram", "cache", "memory"]
 categories = ["memory-management", "caching"]
 
 [dependencies]
-get-size-derive = { version = "^0.1", optional = true }
+get-size-derive = { version = "^0.1.2", optional = true }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ get-size = { version = "^0.1", features = ["derive"] }
 
 Then you can easily derive [`GetSize`]. If you want the derive macro to ignore a certain struct field you can add the `ignore` attribute to it. This might be usefull if some values do not implement the [`GetSize`] trait and do not have data on the heap, or if the data on the heap has already been accounted for somewhere else.
 
+### Example
+
 ```rust
 use get_size::GetSize;
 
@@ -110,7 +112,9 @@ fn main() {
 }
 ```
 
-As already mentioned you can also derive [`GetSize`] for enums:
+As already mentioned you can also derive [`GetSize`] for enums.
+
+### Example
 
 ```rust
 use get_size::GetSize;
@@ -152,7 +156,7 @@ You can also derive [`GetSize`] on structs and enums with generics. In that case
 
 This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
 
-# Example
+### Example
 
 ```rust
 use get_size::GetSize;

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This library follows the idea that only bytes owned by a certain object should b
 
 ```rust
 use get_size::GetSize;
+use get_size_derive::*;
+
+#[derive(GetSize)]
+struct Test<'a> {
+  value: &'a String,
+}
 
 fn main() {
   let value = String::from("hello");
@@ -23,7 +29,23 @@ fn main() {
   // This string occupies 5 bytes at the heap, but a pointer is treated as not occupying
   // anything at the heap.
   assert_eq!(value.get_heap_size(), 5);
-  assert_eq!((&value).get_heap_size(), 0);
+  assert_eq!(GetSize::get_heap_size(&&value), 0); // Fully qualified syntax
+
+  // WARNING: Duo to rust's automatic dereferencing, a simple pointer will be dereferenced
+  // to the original value, causing the borrowed bytes to be accounted for too.
+  assert_eq!((&value).get_heap_size(), 5);
+  // The above gets rewritten by to compiler into:
+  // assert_eq!(value.get_heap_size(), 5);
+
+  // Our derive macro uses fully qualified syntax, so auto-dereferencing does
+  // not occour.
+  let value = Test {
+    value: &value,
+  };
+
+  // The String is now only borrowed, leading to its heap bytes not being
+  // accounted for.
+  assert_eq!(value.get_heap_size(), 0);
 }
 ```
 
@@ -41,8 +63,9 @@ fn main() {
 
   // From a technical point of view, Arcs own the data they reference.
   // Given so their heap data gets accounted for too.
+  // Note that an Arc does store the String's stack bytes also inside the heap.
   let value = Arc::new(value);
-  assert_eq!(value.get_heap_size(), 5);
+  assert_eq!(value.get_heap_size(), std::mem::size_of::<String>() + 5);
 }
 ```
 

--- a/get-size-derive/Cargo.toml
+++ b/get-size-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "get-size-derive"
 description = "Derives the GetSize trait."
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Denis Kerp"]
 readme = "README.md"
@@ -14,8 +14,8 @@ categories = ["memory-management", "caching"]
 proc-macro = true
 
 [dependencies]
-syn = "^1"
+syn = { version = "^1", features = ["derive"] }
 quote = "^1"
 
 [dev-dependencies]
-get-size = { path = "../../get-size"}
+get-size = "^0.1"

--- a/get-size-derive/LICENSE
+++ b/get-size-derive/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Denis Kerp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/get-size-derive/README.md
+++ b/get-size-derive/README.md
@@ -1,5 +1,9 @@
 # get-size-derive
 
+[![Crates.io](https://img.shields.io/crates/v/get-size-derive)](https://crates.io/crates/get-size-derive)
+[![docs.rs](https://img.shields.io/docsrs/get-size-derive)](https://docs.rs/get-size-derive)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/DKerp/get-size/blob/main/get-size-derive/LICENSE)
+
 Derives [`GetSize`] for structs and enums.
 
 The derive macro will provide a costum implementation of the [`get_heap_size`] method, which will simply call [`get_heap_size`] on all contained values and add the values up. This implies that all values contained in the struct or enum most implement the [`GetSize`] trait themselves.
@@ -20,6 +24,48 @@ pub struct OwnStruct {
 // Does not implement GetSize, so we ignore it.
 pub struct ExternalStruct {
     value1: u8,
+}
+```
+
+You can also derive [`GetSize`] on structs and enums with generics. In that case the generated trait implementation will require all generic types to also implement [`GetSize`].
+
+This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
+
+# Example
+
+```rust
+use get_size::GetSize;
+use get_size_derive::*;
+
+#[derive(GetSize)]
+#[get_size(ignore(B, C))]
+struct TestStructGenericsIgnore<A, B, C> {
+    value1: A,
+    #[get_size(ignore)]
+    value2: B,
+    #[get_size(ignore)]
+    value3: C,
+}
+
+// Does not implement GetSize, so we ignore it.
+struct TestStructNoGetSize {
+    value: String,
+}
+
+fn main() {
+    let no_impl = TestStructNoGetSize {
+        value: "World!".into(),
+    };
+
+    // If we did not ignore the C type, the following would not implement
+    // GetSize since C does not implement it.
+    let test: TestStructGenericsIgnore<String, u64, TestStructNoGetSize> = TestStructGenericsIgnore {
+        value1: "Hello".into(),
+        value2: 123,
+        value3: no_impl,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
 }
 ```
 

--- a/get-size-derive/README.md
+++ b/get-size-derive/README.md
@@ -31,7 +31,7 @@ You can also derive [`GetSize`] on structs and enums with generics. In that case
 
 This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
 
-# Example
+## Example
 
 ```rust
 use get_size::GetSize;

--- a/get-size-derive/src/lib.md
+++ b/get-size-derive/src/lib.md
@@ -1,6 +1,6 @@
 Derives [`GetSize`] for structs and enums.
 
-The derive macro will provide a costum implementation of the [`get_heap_size`] method, which will simply call [`get_heap_size`] on all contained values and add the values up. This implies that all values contained in the struct or enum most implement the [`GetSize`] trait themselves.
+The derive macro will provide a costum implementation of the [`get_heap_size`] method, which will simply call [`get_heap_size`] on all contained values and add the values up. This implies that all values contained in the struct or enum must implement the [`GetSize`] trait themselves.
 
 When deriving [`GetSize`] for structs you can use the `ignore` attribute to make the derive macro ignore certain values. This might be usefull if some values do not implement the [`GetSize`] trait and do not have data on the heap, or if the data on the heap has already been accounted for somewhere else.
 
@@ -21,6 +21,48 @@ pub struct OwnStruct {
 // Does not implement GetSize, so we ignore it.
 pub struct ExternalStruct {
     value1: u8,
+}
+```
+
+You can also derive [`GetSize`] on structs and enums with generics. In that case the generated trait implementation will require all generic types to also implement [`GetSize`].
+
+This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
+
+# Example
+
+```
+use get_size::GetSize;
+use get_size_derive::*;
+
+#[derive(GetSize)]
+#[get_size(ignore(B, C))]
+struct TestStructGenericsIgnore<A, B, C> {
+    value1: A,
+    #[get_size(ignore)]
+    value2: B,
+    #[get_size(ignore)]
+    value3: C,
+}
+
+// Does not implement GetSize, so we ignore it.
+struct TestStructNoGetSize {
+    value: String,
+}
+
+fn main() {
+    let no_impl = TestStructNoGetSize {
+        value: "World!".into(),
+    };
+
+    // If we did not ignore the C type, the following would not implement
+    // GetSize since C does not implement it.
+    let test: TestStructGenericsIgnore<String, u64, TestStructNoGetSize> = TestStructGenericsIgnore {
+        value1: "Hello".into(),
+        value2: 123,
+        value3: no_impl,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
 }
 ```
 

--- a/src/lib.md
+++ b/src/lib.md
@@ -2,11 +2,11 @@ Determine the size in bytes an object occupies inside RAM.
 
 The [`GetSize`] trait can be used to determine the size of an object inside the stack as well as in the heap. The [`size_of`](std::mem::size_of) function provided by the standard library can already be used to determine the size of an object in the stack, but many application (e.g. for caching) do also need to know the number of bytes occupied inside the heap, for which this library provides an appropriate trait.
 
-## Ownership based accounting
+# Ownership based accounting
 
 This library follows the idea that only bytes owned by a certain object should be accounted for, and not bytes owned by different objects which are only borrowed. This means in particular that objects referenced by pointers are ignored.
 
-### Example
+## Example
 
 ```rust
 use get_size::GetSize;
@@ -45,7 +45,7 @@ fn main() {
 
 On the other hand references implemented as shared ownership are treated as owned values. It is your responsibility to ensure that the bytes occupied by them are not counted twice in your application!
 
-### Example
+## Example
 
 ```rust
 use std::sync::Arc;
@@ -77,6 +77,8 @@ get-size = { version = "^0.1", features = ["derive"] }
 
 Then you can easily derive [`GetSize`]. If you want the derive macro to ignore a certain struct field you can add the `ignore` attribute to it. This might be usefull if some values do not implement the [`GetSize`] trait and do not have data on the heap, or if the data on the heap has already been accounted for somewhere else.
 
+## Example
+
 ```rust
 use get_size::GetSize;
 
@@ -104,7 +106,9 @@ fn main() {
 }
 ```
 
-As already mentioned you can also derive [`GetSize`] for enums:
+As already mentioned you can also derive [`GetSize`] for enums.
+
+## Example
 
 ```rust
 use get_size::GetSize;
@@ -146,7 +150,7 @@ You can also derive [`GetSize`] on structs and enums with generics. In that case
 
 This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
 
-# Example
+## Example
 
 ```rust
 use get_size::GetSize;

--- a/src/lib.md
+++ b/src/lib.md
@@ -2,6 +2,67 @@ Determine the size in bytes an object occupies inside RAM.
 
 The [`GetSize`] trait can be used to determine the size of an object inside the stack as well as in the heap. The [`size_of`](std::mem::size_of) function provided by the standard library can already be used to determine the size of an object in the stack, but many application (e.g. for caching) do also need to know the number of bytes occupied inside the heap, for which this library provides an appropriate trait.
 
+## Ownership based accounting
+
+This library follows the idea that only bytes owned by a certain object should be accounted for, and not bytes owned by different objects which are only borrowed. This means in particular that objects referenced by pointers are ignored.
+
+### Example
+
+```rust
+use get_size::GetSize;
+use get_size_derive::*;
+
+#[derive(GetSize)]
+struct Test<'a> {
+  value: &'a String,
+}
+
+fn main() {
+  let value = String::from("hello");
+
+  // This string occupies 5 bytes at the heap, but a pointer is treated as not occupying
+  // anything at the heap.
+  assert_eq!(value.get_heap_size(), 5);
+  assert_eq!(GetSize::get_heap_size(&&value), 0); // Fully qualified syntax
+
+  // WARNING: Duo to rust's automatic dereferencing, a simple pointer will be dereferenced
+  // to the original value, causing the borrowed bytes to be accounted for too.
+  assert_eq!((&value).get_heap_size(), 5);
+  // The above gets rewritten by to compiler into:
+  // assert_eq!(value.get_heap_size(), 5);
+
+  // Our derive macro uses fully qualified syntax, so auto-dereferencing does
+  // not occour.
+  let value = Test {
+    value: &value,
+  };
+
+  // The String is now only borrowed, leading to its heap bytes not being
+  // accounted for.
+  assert_eq!(value.get_heap_size(), 0);
+}
+```
+
+On the other hand references implemented as shared ownership are treated as owned values. It is your responsibility to ensure that the bytes occupied by them are not counted twice in your application!
+
+### Example
+
+```rust
+use std::sync::Arc;
+use get_size::GetSize;
+
+fn main() {
+  let value = String::from("hello");
+  assert_eq!(value.get_heap_size(), 5);
+
+  // From a technical point of view, Arcs own the data they reference.
+  // Given so their heap data gets accounted for too.
+  // Note that an Arc does store the String's stack bytes also inside the heap.
+  let value = Arc::new(value);
+  assert_eq!(value.get_heap_size(), std::mem::size_of::<String>() + 5);
+}
+```
+
 # How to implement
 
 The [`GetSize`] trait is already implemented for most objects defined by the standard library, like [`Vec`](std::vec::Vec), [`HashMap`](std::collections::HashMap), [`String`] as well as all the primitive values, like [`u8`], [`i32`] etc.
@@ -78,6 +139,48 @@ fn main() {
 
     let test = TestEnumNumber::One;
     assert_eq!(test.get_heap_size(), 0);
+}
+```
+
+You can also derive [`GetSize`] on structs and enums with generics. In that case the generated trait implementation will require all generic types to also implement [`GetSize`].
+
+This behavior may be unfavourable if one or more generic types are ignored duo to the corresponding struct field being ignored. In that case you can also use the `ignore` attribute at the struct level to specifiy the generic parameters which shall not be required to implement [`GetSize`] themselves.
+
+# Example
+
+```rust
+use get_size::GetSize;
+use get_size_derive::*;
+
+#[derive(GetSize)]
+#[get_size(ignore(B, C))]
+struct TestStructGenericsIgnore<A, B, C> {
+    value1: A,
+    #[get_size(ignore)]
+    value2: B,
+    #[get_size(ignore)]
+    value3: C,
+}
+
+// Does not implement GetSize, so we ignore it.
+struct TestStructNoGetSize {
+    value: String,
+}
+
+fn main() {
+    let no_impl = TestStructNoGetSize {
+        value: "World!".into(),
+    };
+
+    // If we did not ignore the C type, the following would not implement
+    // GetSize since C does not implement it.
+    let test: TestStructGenericsIgnore<String, u64, TestStructNoGetSize> = TestStructGenericsIgnore {
+        value1: "Hello".into(),
+        value2: 123,
+        value3: no_impl,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ where
 {
     fn get_heap_size(&self) -> usize {
         match self {
-            Self::Borrowed(borrowed) => GetSize::get_heap_size(borrowed),
+            Self::Borrowed(borrowed) => 0,
             Self::Owned(owned) => GetSize::get_heap_size(owned),
         }
     }
@@ -267,17 +267,7 @@ impl<T, const SIZE: usize> GetSize for [T; SIZE] where T: GetSize {
     }
 }
 
-impl<T> GetSize for &[T] where T: GetSize {
-    fn get_heap_size(&self) -> usize {
-        let mut total = 0;
-
-        for element in self.iter() {
-            total += GetSize::get_size(element);
-        }
-
-        total
-    }
-}
+impl<T> GetSize for &[T] where T: GetSize {}
 
 impl<T> GetSize for &T {}
 impl<T> GetSize for &mut T {}
@@ -343,11 +333,7 @@ impl GetSize for String {
     }
 }
 
-impl GetSize for &str {
-    fn get_heap_size(&self) -> usize {
-        GetSize::get_heap_size(&self.as_bytes())
-    }
-}
+impl GetSize for &str {}
 
 impl GetSize for std::ffi::CString {
     fn get_heap_size(&self) -> usize {
@@ -421,8 +407,4 @@ impl GetSize for std::path::PathBuf {
 
 #[cfg(unix)]
 #[cfg_attr(docsrs, doc(cfg(unix)))]
-impl GetSize for &std::path::Path {
-    fn get_heap_size(&self) -> usize {
-        GetSize::get_heap_size(&self.as_os_str())
-    }
-}
+impl GetSize for &std::path::Path {}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,6 +17,71 @@ fn derive_struct() {
 }
 
 #[derive(GetSize)]
+pub struct TestStructGenerics<A, B> {
+    value1: A,
+    value2: B,
+}
+
+#[test]
+fn derive_struct_with_generics() {
+    let test: TestStructGenerics<String, u64> = TestStructGenerics {
+        value1: "Hello".into(),
+        value2: 123,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
+}
+
+#[derive(GetSize)]
+#[get_size(ignore(B, C))]
+#[allow(dead_code)]
+struct TestStructGenericsIgnore<A, B, C> {
+    value1: A,
+    #[get_size(ignore)]
+    value2: B,
+    #[get_size(ignore)]
+    value3: C,
+}
+
+#[allow(dead_code)]
+struct TestStructNoGetSize {
+    value: String,
+}
+
+#[test]
+fn derive_struct_with_generics_and_ignore() {
+    let no_impl = TestStructNoGetSize {
+        value: "World!".into(),
+    };
+
+    let test: TestStructGenericsIgnore<String, u64, TestStructNoGetSize> = TestStructGenericsIgnore {
+        value1: "Hello".into(),
+        value2: 123,
+        value3: no_impl,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
+}
+
+#[derive(GetSize)]
+pub struct TestStructGenericsLifetimes<'a, A, B> {
+    value1: A,
+    value2: &'a B,
+}
+
+#[test]
+fn derive_struct_with_generics_and_lifetimes() {
+    let value = 123u64;
+
+    let test: TestStructGenericsLifetimes<String, u64> = TestStructGenericsLifetimes {
+        value1: "Hello".into(),
+        value2: &value,
+    };
+
+    assert_eq!(test.get_heap_size(), 5);
+}
+
+#[derive(GetSize)]
 pub enum TestEnum {
     Variant1(u8, u16, u32),
     Variant2(String),
@@ -54,6 +119,60 @@ fn derive_enum() {
 
     let test = TestEnum::Variant7{x: "Hello".into(), y: "world".into()};
     assert_eq!(test.get_heap_size(), 5 + 5);
+}
+
+#[derive(GetSize)]
+pub enum TestEnumGenerics<'a, A, B, C> {
+    Variant1(A),
+    Variant2(B),
+    Variant3(&'a C),
+}
+
+#[test]
+fn derive_enum_generics() {
+    let test: TestEnumGenerics<u64, String, TestStruct> = TestEnumGenerics::Variant1(123);
+    assert_eq!(test.get_heap_size(), 0);
+
+    let test: TestEnumGenerics<u64, String, TestStruct> = TestEnumGenerics::Variant2("Hello".into());
+    assert_eq!(test.get_heap_size(), 5);
+
+    let test_struct = TestStruct {
+        value1: "Hello world".into(),
+        value2: 123,
+    };
+
+    let test: TestEnumGenerics<u64, String, TestStruct> = TestEnumGenerics::Variant3(&test_struct);
+    assert_eq!(test.get_heap_size(), 0); // It is a pointer.
+}
+
+
+const MINIMAL_NODE_SIZE: usize = 3;
+
+#[derive(Clone, GetSize)]
+enum Node<T> where T: Default {
+    Block(T),
+    Blocks(Box<[T; MINIMAL_NODE_SIZE * MINIMAL_NODE_SIZE * MINIMAL_NODE_SIZE]>),
+    Nodes(Box<[Node<T>; 8]>),
+}
+
+#[test]
+fn derive_enum_generics_issue1() {
+    let test: Node<String> = Node::Block("test".into());
+    assert_eq!(test.get_heap_size(), 4);
+
+    let test: Node<u64> = Node::Blocks(Box::new([123; 27]));
+    assert_eq!(test.get_heap_size(), 8*27);
+
+    let t1: Node<u64> = Node::Block(123);
+    let t2 = t1.clone();
+    let t3 = t1.clone();
+    let t4 = t1.clone();
+    let t5 = t1.clone();
+    let t6 = t1.clone();
+    let t7 = t1.clone();
+    let t8 = t1.clone();
+    let test: Node<u64> = Node::Nodes(Box::new([t1,t2,t3,t4,t5,t6,t7,t8]));
+    assert_eq!(test.get_heap_size(), 8*std::mem::size_of::<Node<u64>>());
 }
 
 #[derive(GetSize)]


### PR DESCRIPTION
Implements support for deriving `GetSize` on structs and enums with generics. Resolves #1. The derive macro does now also support lifetimes.

Furthermore a struct level `ignore` attribute used by the derive macro has been added, which allows specifying the generic types which can be ignored while deriving `GetSize`. All other types will be required to also implement `GetSize`.

Additionally I have specified the accounting rules which this crate follows, and updated the implementation for the `std` library artifacts accordingly.