### PR TITLE
Use capacity for accounting. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "get-size"
 description = "Determine the size in bytes an object occupies inside RAM."
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Denis Kerp"]
 readme = "README.md"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -103,8 +103,12 @@ fn derive_enum() {
     let test = TestEnum::Variant3(-12, vec![1, 2, 3]);
     assert_eq!(test.get_heap_size(), 6);
 
-    let test = TestEnum::Variant4("Test".into(), -123, vec![1, 2, 3, 4], false, "Hello world!");
-    assert_eq!(test.get_heap_size(), 4 + 16 + 12);
+    let s: String = "Test".into();
+    assert_eq!(s.get_heap_size(), 4);
+    let v = vec![1, 2, 3, 4];
+    assert_eq!(v.get_heap_size(), 16);
+    let test = TestEnum::Variant4(s, -123, v, false, "Hello world!");
+    assert_eq!(test.get_heap_size(), 4 + 16);
 
     let test_struct = TestStruct {
         value1: "Hello world".into(),


### PR DESCRIPTION
The old implementation used `.len()` on most `std` object to do the heap accounting. We now use `.capacity()` to account for the entire allocated space on the heap.

On certain objects (e.g. `Vec`) this implies multiplying the not used capacity with the stack size of the contained objects.

Fixes #3.