### PR TITLE
Implement GetSize for Box<[T]>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,3 +437,14 @@ impl GetSize for std::path::PathBuf {
 }
 
 impl GetSize for &std::path::Path {}
+
+impl<T> GetSize for Box<[T]> {
+    fn get_heap_size(&self) -> usize {
+        let mut total = 0;
+        for item in self.iter() {
+            total += item.get_size()
+        }
+
+        total
+    }
+}


### PR DESCRIPTION
Heya, implementing this would save us having to tear up our downstream codebase to use a newtype wherever we have these.