### PR TITLE
Add tracker support for shared ownership objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ keywords = ["size", "heap", "ram", "cache", "memory"]
 categories = ["memory-management", "caching"]
 
 [dependencies]
-get-size-derive = { version = "^0.1.3", optional = true }
+# get-size-derive = { version = "^0.1.3", optional = true }
+get-size-derive = { path = "get-size-derive", optional = true }
+
+[dev-dependencies]
+get-size = { path = ".", features = ["derive"] }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,11 @@ impl<T> GetSize for Box<T> where T: GetSize {
 
 impl<T> GetSize for Rc<T> where T: GetSize + 'static {
     fn get_heap_size(&self) -> usize {
-        GetSize::get_size(&**self)
+        let tracker = StandardTracker::default();
+
+        let (total, _) = GetSize::get_heap_size_with_tracker(self, tracker);
+
+        total
     }
 
     fn get_heap_size_with_tracker<TR: GetSizeTracker>(
@@ -357,7 +361,7 @@ impl<T> GetSize for Rc<T> where T: GetSize + 'static {
         let addr = Rc::as_ptr(&strong_ref);
 
         if tracker.track(addr, strong_ref) {
-            (GetSize::get_size(&**self), tracker)
+            GetSize::get_size_with_tracker(&**self, tracker)
         } else {
             (0, tracker)
         }
@@ -368,7 +372,11 @@ impl<T> GetSize for RcWeak<T> {}
 
 impl<T> GetSize for Arc<T> where T: GetSize + 'static {
     fn get_heap_size(&self) -> usize {
-        GetSize::get_size(&**self)
+        let tracker = StandardTracker::default();
+
+        let (total, _) = GetSize::get_heap_size_with_tracker(self, tracker);
+
+        total
     }
 
     fn get_heap_size_with_tracker<TR: GetSizeTracker>(
@@ -380,7 +388,7 @@ impl<T> GetSize for Arc<T> where T: GetSize + 'static {
         let addr = Arc::as_ptr(&strong_ref);
 
         if tracker.track(addr, strong_ref) {
-            (GetSize::get_size(&**self), tracker)
+            GetSize::get_size_with_tracker(&**self, tracker)
         } else {
             (0, tracker)
         }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,0 +1,166 @@
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, RwLock};
+
+
+
+/// A tracker which makes sure that shared ownership objects are only accounted for once.
+pub trait GetSizeTracker {
+    /// Tracks a given strong shared ownership object `strong_ref` of type `A`, which points
+    /// to an arbitrary object located at `addr`.
+    ///
+    /// Returns `true` if the reference, as indexed by the pointed to `addr`, has not yet
+    /// been seen by this tracker. Otherwise it returns false.
+    ///
+    /// If the `addr` has not yet been seen, the tracker __MUST__ store the `strong_ref`
+    /// object to ensure that the `addr` pointed to by it remains valid for the trackers
+    /// lifetime.
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool;
+}
+
+
+impl<T: GetSizeTracker> GetSizeTracker for &mut T {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        GetSizeTracker::track(*self, addr, strong_ref)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for Box<T> {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        GetSizeTracker::track(&mut **self, addr, strong_ref)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for Mutex<T> {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        let mut tracker = self.lock().unwrap();
+
+        GetSizeTracker::track(&mut *tracker, addr, strong_ref)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for RwLock<T> {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        let mut tracker = self.write().unwrap();
+
+        GetSizeTracker::track(&mut *tracker, addr, strong_ref)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for Arc<Mutex<T>> {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        let mut tracker = self.lock().unwrap();
+
+        GetSizeTracker::track(&mut *tracker, addr, strong_ref)
+    }
+}
+
+impl<T: GetSizeTracker> GetSizeTracker for Arc<RwLock<T>> {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        let mut tracker = self.write().unwrap();
+
+        GetSizeTracker::track(&mut *tracker, addr, strong_ref)
+    }
+}
+
+
+
+/// A simple standard tracker which can be used to track shared ownership references.
+#[derive(Debug, Default)]
+pub struct StandardTracker {
+    inner: BTreeMap<usize, Box<dyn Any + 'static>>,
+}
+
+impl StandardTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl GetSizeTracker for StandardTracker {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        addr: *const B,
+        strong_ref: A,
+    ) -> bool {
+        let addr = addr as usize;
+
+        if self.inner.contains_key(&addr) {
+            return false;
+        } else {
+            let strong_ref: Box<dyn Any + 'static> = Box::new(strong_ref);
+
+            self.inner.insert(addr, strong_ref);
+
+            return true;
+        }
+    }
+}
+
+
+/// A pseudo tracker which does not track anything.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoTracker {
+    answer: bool,
+}
+
+impl NoTracker {
+    /// Creates a new pseudo tracker, which will always return the given `answer`.
+    pub fn new(answer: bool) -> Self {
+        Self {
+            answer
+        }
+    }
+
+    /// Get the answer which will always be returned by this pseudo tracker.
+    pub fn answer(&self) -> bool {
+        self.answer
+    }
+
+    /// Changes the answer which will always be returned by this pseudo tracker.
+    pub fn set_answer(&mut self, answer: bool) {
+        self.answer = answer;
+    }
+}
+
+impl GetSizeTracker for NoTracker {
+    fn track<A: Any + 'static, B>(
+        &mut self,
+        _addr: *const B,
+        _strong_ref: A,
+    ) -> bool {
+        self.answer
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,6 @@
-use super::*;
+use get_size::*;
+
+
 
 #[derive(GetSize)]
 pub struct TestStruct {


### PR DESCRIPTION
Makes sure that objects, which are stored in a shared ownership fashion like e.g. inside an `Arc`, are only accounted for once.