### PR TITLE
Update `attribute-derive` dep to latest

### DIFF
--- a/get-size-derive/Cargo.toml
+++ b/get-size-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "get-size-derive"
 description = "Derives the GetSize trait."
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Denis Kerp"]
 readme = "README.md"
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "^2", features = ["derive", "parsing"] }
 quote = "^1"
-attribute-derive = "^0.6"
+attribute-derive = "^0.9"
 
 [dev-dependencies]
 get-size = { path = "../", features = ["derive"] }

--- a/get-size-derive/src/lib.rs
+++ b/get-size-derive/src/lib.rs
@@ -4,11 +4,11 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn;
-use attribute_derive::Attribute;
+use attribute_derive::{Attribute, FromAttr};
 
 
 
-#[derive(Attribute, Default, Debug)]
+#[derive(FromAttr, Default, Debug)]
 #[attribute(ident = get_size)]
 struct StructFieldAttribute {
     #[attribute(conflicts = [size_fn, ignore])]


### PR DESCRIPTION
I noticed that the dependency `attribute-derive` was 3 major versions behind, and that the updates required to use the newest version were minor.

All tests pass.