### PR TITLE
Fix Box<[T]> sizing to make it account for element sizes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,7 @@ impl GetSize for std::path::PathBuf {
 
 impl GetSize for &std::path::Path {}
 
-impl<T> GetSize for Box<[T]> {
+impl<T> GetSize for Box<[T]> where T: GetSize {
     fn get_heap_size(&self) -> usize {
         let mut total = 0;
         for item in self.iter() {


### PR DESCRIPTION
See: https://github.com/DKerp/get-size/pull/6#discussion_r1821508880

Without this change we only count one pointer for each element.